### PR TITLE
Apply all cursor roles (incl. Wait/AppStarting), not only Arrow/Hand / 应用全部光标角色（含忙碌/后台运行），而不止 Arrow/Hand

### DIFF
--- a/Apply-CurrentCursorScheme.ps1
+++ b/Apply-CurrentCursorScheme.ps1
@@ -21,35 +21,71 @@ public static class CursorSchemeNative
 }
 
 $cursorSettings = Get-ItemProperty -LiteralPath 'Registry::HKEY_CURRENT_USER\Control Panel\Cursors'
+
+# Registry value name -> OCR_* id accepted by SetSystemCursor.
+# NWPen/Person/Pin have no OCR_* slot, so SetSystemCursor cannot restore them.
 $cursorMappings = @(
-    [pscustomobject]@{ Role = 'Arrow'; CursorId = [uint32]32512 }
-    [pscustomobject]@{ Role = 'Hand'; CursorId = [uint32]32649 }
+    [pscustomobject]@{ Role = 'Arrow';       CursorId = [uint32]32512 }  # OCR_NORMAL
+    [pscustomobject]@{ Role = 'Help';        CursorId = [uint32]32651 }  # OCR_HELP
+    [pscustomobject]@{ Role = 'AppStarting'; CursorId = [uint32]32650 }  # OCR_APPSTARTING
+    [pscustomobject]@{ Role = 'Wait';        CursorId = [uint32]32514 }  # OCR_WAIT
+    [pscustomobject]@{ Role = 'Crosshair';   CursorId = [uint32]32515 }  # OCR_CROSS
+    [pscustomobject]@{ Role = 'IBeam';       CursorId = [uint32]32513 }  # OCR_IBEAM
+    [pscustomobject]@{ Role = 'No';          CursorId = [uint32]32648 }  # OCR_NO
+    [pscustomobject]@{ Role = 'SizeNS';      CursorId = [uint32]32645 }  # OCR_SIZENS
+    [pscustomobject]@{ Role = 'SizeWE';      CursorId = [uint32]32644 }  # OCR_SIZEWE
+    [pscustomobject]@{ Role = 'SizeNWSE';    CursorId = [uint32]32642 }  # OCR_SIZENWSE
+    [pscustomobject]@{ Role = 'SizeNESW';    CursorId = [uint32]32643 }  # OCR_SIZENESW
+    [pscustomobject]@{ Role = 'SizeAll';     CursorId = [uint32]32646 }  # OCR_SIZEALL
+    [pscustomobject]@{ Role = 'UpArrow';     CursorId = [uint32]32516 }  # OCR_UP
+    [pscustomobject]@{ Role = 'Hand';        CursorId = [uint32]32649 }  # OCR_HAND
 )
 
+$appliedCount = 0
+$failures = New-Object System.Collections.Generic.List[string]
+
 foreach ($mapping in $cursorMappings) {
-    $configuredPath = $cursorSettings.($mapping.Role)
+    $configuredPath = $null
+    if ($cursorSettings.PSObject.Properties.Name -contains $mapping.Role) {
+        $configuredPath = $cursorSettings.($mapping.Role)
+    }
+
+    # A role the current scheme leaves empty is skipped instead of treated as an error.
     if ([string]::IsNullOrWhiteSpace($configuredPath)) {
-        throw "The $($mapping.Role) cursor path is empty."
+        Write-Verbose "Skipping $($mapping.Role): the current scheme does not configure this role."
+        continue
     }
 
     $cursorPath = [Environment]::ExpandEnvironmentVariables($configuredPath)
     if (-not (Test-Path -LiteralPath $cursorPath -PathType Leaf)) {
-        throw "The $($mapping.Role) cursor file does not exist: $cursorPath"
+        $failures.Add("The $($mapping.Role) cursor file does not exist: $cursorPath")
+        continue
     }
 
     $cursorHandle = [CursorSchemeNative]::LoadCursorFromFile($cursorPath)
     if ($cursorHandle -eq [IntPtr]::Zero) {
         $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        throw "LoadCursorFromFile failed for $cursorPath. Win32 error: $errorCode"
+        $failures.Add("LoadCursorFromFile failed for $($mapping.Role) ($cursorPath). Win32 error: $errorCode")
+        continue
     }
 
     if (-not [CursorSchemeNative]::SetSystemCursor($cursorHandle, $mapping.CursorId)) {
         $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
         [void][CursorSchemeNative]::DestroyCursor($cursorHandle)
-        throw "SetSystemCursor failed for $($mapping.Role). Win32 error: $errorCode"
+        $failures.Add("SetSystemCursor failed for $($mapping.Role). Win32 error: $errorCode")
+        continue
     }
 
     Write-Host "Applied $($mapping.Role): $cursorPath"
+    $appliedCount++
 }
 
-Write-Host 'The current Arrow and Hand cursors are active.'
+if ($appliedCount -eq 0) {
+    throw "No cursor role could be applied. $($failures.Count) role(s) failed: $($failures -join ' | ')"
+}
+
+if ($failures.Count -gt 0) {
+    throw "Applied $appliedCount cursor role(s), but $($failures.Count) role(s) failed: $($failures -join ' | ')"
+}
+
+Write-Host "The current cursor scheme is active ($appliedCount role(s) applied)."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Windows 11 自定义光标主题 Arrow/Hand 不生效或始终显示 Windows Aero 光标主题的问题修复
+# Windows 11 自定义光标主题不生效（Arrow/Hand/忙碌等）或始终显示 Windows Aero 光标主题的问题修复
 
-更新了 Windows 11 最新版后发现，在部分 Windows 11 环境中，自定义鼠标光标方案已经正确安装，注册表中的路径也完全正确，但屏幕实际显示的“正常选择”（Arrow）和“链接选择”（Hand）仍然是 Windows 经典光标。
+更新了 Windows 11 最新版后发现，在部分 Windows 11 环境中，自定义鼠标光标方案已经正确安装，注册表中的路径也完全正确，但屏幕实际显示的“正常选择”（Arrow）、“链接选择”（Hand）、“忙碌”（Wait）、“后台运行”（AppStarting）等光标仍然是 Windows 经典样式。
 
-本项目提供一个无需管理员权限的临时修复：读取当前用户所选方案中的 `Arrow` 和 `Hand` 文件，通过 Windows 官方 `SetSystemCursor` API 将它们重新装载到当前登录会话。
+本项目提供一个无需管理员权限的临时修复：读取当前用户所选方案中全部 14 个受支持光标角色（`Arrow`、`Hand`、`Wait`、`AppStarting` 等）的文件，通过 Windows 官方 `SetSystemCursor` API 将它们重新装载到当前登录会话。
 
 ## 已复现环境
 
@@ -16,9 +16,9 @@
 ## 症状
 
 - `main.cpl` 的“指针”页面可以看到并选择第三方方案。
-- `HKEY_CURRENT_USER\Control Panel\Cursors` 中的 `Arrow` 和 `Hand` 已指向正确的第三方 `.cur` 文件。
+- `HKEY_CURRENT_USER\Control Panel\Cursors` 中的各光标角色已指向正确的第三方 `.cur`/`.ani` 文件。
 - 光标文件存在，并且可以通过 `LoadCursorFromFileW` 正常加载。
-- 点击“应用”、重启应用，甚至注销后重新登录，Arrow/Hand 仍可能显示为 Windows 经典样式。
+- 点击“应用”、重启应用，甚至注销后重新登录，部分或全部光标角色仍可能显示为 Windows 经典样式。
 - 其他光标状态可能正常，或因为外观接近而不容易发现异常。
 
 ## 调查结论
@@ -26,7 +26,7 @@
 已确认的事实：
 
 1. 光标包安装成功，文件和注册表路径均正确。
-2. Windows 当前会话中的 `OCR_NORMAL` 和 `OCR_HAND` 系统光标内容仍是经典样式，与注册表指定文件不一致。
+2. Windows 当前会话中的 `OCR_NORMAL`、`OCR_HAND`、`OCR_WAIT` 等系统光标槽位内容仍是经典样式，与注册表指定文件不一致。
 3. 直接调用 `SetSystemCursor` 后，系统光标与注册表指定文件的像素内容完全一致，屏幕显示立即恢复正常。
 
 因此，问题发生在“注册表方案 -> 当前登录会话的系统光标槽位”这一装载环节，而不是光标文件损坏或安装路径错误。
@@ -39,7 +39,7 @@
 
 1. 先通过 Windows 设置或 `main.cpl` 选择所需的自定义光标方案。
 2. 双击 `Apply-CurrentCursorScheme.cmd`。
-3. Arrow 和 Hand 应立即变为当前方案中的样式。
+3. 所有已配置的光标角色应立即变为当前方案中的样式。
 
 不要使用“以管理员身份运行”。脚本必须在日常登录账户下执行，才能读取正确的 `HKEY_CURRENT_USER`。
 
@@ -65,11 +65,13 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".\Apply-CurrentCursorSc
 
 脚本只执行以下操作：
 
-1. 读取 `HKEY_CURRENT_USER\Control Panel\Cursors` 中的 `Arrow` 和 `Hand`。
+1. 读取 `HKEY_CURRENT_USER\Control Panel\Cursors` 中 14 个受支持的光标角色（`Arrow`、`Hand`、`Wait`、`AppStarting` 等）。
 2. 展开路径里的 `%SYSTEMROOT%` 等环境变量。
-3. 检查 `.cur` 文件是否存在。
+3. 检查 `.cur`/`.ani` 文件是否存在。
 4. 使用 `LoadCursorFromFileW` 加载光标。
-5. 使用 `SetSystemCursor` 替换当前会话中的 `OCR_NORMAL` 和 `OCR_HAND`。
+5. 使用 `SetSystemCursor` 替换当前会话中对应的全部系统光标槽位（`OCR_NORMAL`、`OCR_HAND`、`OCR_WAIT`、`OCR_APPSTARTING` 等 14 项）。
+
+方案中未配置（注册表值为空）的角色会被跳过；某个角色失败不会阻止其他角色应用，但脚本最后会以错误退出并列出失败的角色。
 
 脚本不会修改注册表，不会下载文件，也不需要管理员权限。
 
@@ -83,9 +85,9 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File ".\Apply-CurrentCursorSc
 
 ## 已知限制
 
-- 当前脚本只修复 Arrow 和 Hand，因为本次问题只在这两个状态上稳定复现。
+- `NWPen`、`Person`、`Pin` 没有对应的 `SetSystemCursor` 槽位，暂无法通过本脚本恢复。
 - 修复不是永久修改；Windows 重新初始化系统光标后可能失效。
-- 如果注册表路径为空、文件不存在或文件格式无效，脚本会停止并显示错误。
+- 注册表中未配置的角色会被跳过；如果某个角色的文件不存在或格式无效，其余角色仍会应用，但脚本最后会报错并列出失败的角色。
 
 ## 参考资料
 


### PR DESCRIPTION
## 问题 / Problem

**中文**

现有脚本只重载 `Arrow`（`OCR_NORMAL`）和 `Hand`（`OCR_HAND`）两个光标槽位。实际使用中发现「忙碌」（`Wait`）、「后台运行」（`AppStarting`）等其余光标也会被还原为 Windows 经典样式，说明该问题并不只发生在这两个状态上，只修 Arrow/Hand 的补丁并不完整。

**English**

The current script only reloads two cursor slots: `Arrow` (`OCR_NORMAL`) and `Hand` (`OCR_HAND`). In practice, the "Busy" (`Wait`) and "Working in background" (`AppStarting`) cursors — and the other roles — also revert to the classic Windows cursors. The issue is therefore not limited to those two states, and the Arrow/Hand-only patch is incomplete.

## 修改内容 / Changes

**中文**

将映射表扩展为 `SetSystemCursor` 官方支持的全部 14 个光标角色：

| 注册表值 / Registry value | OCR 常量 / OCR constant | ID |
|---|---|---|
| `Arrow` | `OCR_NORMAL` | 32512 |
| `Help` | `OCR_HELP` | 32651 |
| `AppStarting` | `OCR_APPSTARTING` | 32650 |
| `Wait` | `OCR_WAIT` | 32514 |
| `Crosshair` | `OCR_CROSS` | 32515 |
| `IBeam` | `OCR_IBEAM` | 32513 |
| `No` | `OCR_NO` | 32648 |
| `SizeNS` | `OCR_SIZENS` | 32645 |
| `SizeWE` | `OCR_SIZEWE` | 32644 |
| `SizeNWSE` | `OCR_SIZENWSE` | 32642 |
| `SizeNESW` | `OCR_SIZENESW` | 32643 |
| `SizeAll` | `OCR_SIZEALL` | 32646 |
| `UpArrow` | `OCR_UP` | 32516 |
| `Hand` | `OCR_HAND` | 32649 |

同时调整了容错行为：

- 方案中未配置（注册表值为空）的角色会被跳过，而不是报错——不少方案会留空个别角色。
- 某个角色的文件缺失或加载失败时，不再中断其余角色；失败项在最后汇总报错退出（全部失败时同样报错），退出码语义与原来一致：有问题即为非零。

`NWPen`、`Person`、`Pin` 没有对应的 `OCR_*` 槽位，无法通过 `SetSystemCursor` 恢复，已在 README「已知限制」中说明。

**English**

The mapping table now covers all 14 cursor roles officially supported by `SetSystemCursor` (see table above). Error handling was also adjusted:

- Roles the scheme leaves empty (empty registry value) are skipped instead of raising an error — many schemes leave individual roles unset.
- A missing or unloadable file for one role no longer aborts the remaining roles; failures are collected and reported together at the end (a total failure still errors out), so the exit-code semantics stay the same as before: non-zero means something went wrong.

`NWPen`, `Person` and `Pin` have no `OCR_*` slot and cannot be restored through `SetSystemCursor`; this is now documented in the "Known limitations" section of the README.

## 验证 / Verification

**中文**

已在 Windows 11 25H2 Insider（第三方方案、14 个角色全部为 `.ani` 动画光标）上实测：14 个角色全部重载成功，忙碌/后台运行光标恢复正常，退出码 0。

**English**

Tested on Windows 11 25H2 Insider with a third-party scheme where all 14 roles are animated `.ani` cursors: all 14 roles reloaded successfully, the busy / working-in-background cursors were restored, and the script exited with code 0.
